### PR TITLE
SQLAlchemy integration

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,7 +25,7 @@
 
 ## データベースについて
 
-Bot は `asyncpg.create_pool` で PostgreSQL などへ接続します。接続情報は `config.DATABASE_URL` で設定できます。テーブル作成用 SQL は `sql/` 配下にまとめています。
+Bot は `SQLAlchemy` の `create_async_engine` でデータベースへ接続します。接続情報は `config.DATABASE_URL` で設定できます。テーブル作成用 SQL は `sql/` 配下にまとめています。
 
 ## テスト
 

--- a/cog/ban.py
+++ b/cog/ban.py
@@ -3,6 +3,8 @@ from discord.ext import commands
 
 import config
 from guild_config import fetch_config
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from db import user_warnings
 
 
 class BanCog(commands.Cog):
@@ -19,18 +21,18 @@ class BanCog(commands.Cog):
             roles = [role.id for role in getattr(message.author, "roles", [])]
             conf = None
             if message.guild:
-                conf = await fetch_config(self.bot.db_pool, message.guild.id)
+                conf = await fetch_config(self.bot.db_engine, message.guild.id)
             allow_role = conf.ban_allow_role_id if conf else config.BAN_ALLOW_ROLE_ID
             if allow_role not in roles:
                 await message.delete()
                 await message.author.ban(reason="スパム検出")
-                async with self.bot.db_pool.acquire() as conn:
-                    await conn.execute(
-                        "INSERT INTO user_warnings (user_id, guild_id, message_content) VALUES ($1, $2, $3)",
-                        message.author.id,
-                        message.guild.id if message.guild else 0,
-                        message.content,
+                async with self.bot.db_engine.begin() as conn:
+                    stmt = pg_insert(user_warnings).values(
+                        user_id=message.author.id,
+                        guild_id=message.guild.id if message.guild else 0,
+                        message_content=message.content,
                     )
+                    await conn.execute(stmt)
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(BanCog(bot))

--- a/cog/setup.py
+++ b/cog/setup.py
@@ -19,24 +19,24 @@ class SetupCog(commands.Cog):
         ban_role: discord.Role,
     ) -> None:
         """アーカイブ用カテゴリーとBAN除外ロールを登録"""
-        await set_config(self.bot.db_pool, ctx.guild.id, archive_category.id, ban_role.id)
+        await set_config(self.bot.db_engine, ctx.guild.id, archive_category.id, ban_role.id)
         await ctx.reply("設定を保存しました。")
 
     @commands.hybrid_command(name="setarchive", description="アーカイブカテゴリーを設定します")
     @commands.has_guild_permissions(administrator=True)
     async def set_archive(self, ctx: commands.Context, category: discord.CategoryChannel) -> None:
-        await update_archive_category(self.bot.db_pool, ctx.guild.id, category.id)
+        await update_archive_category(self.bot.db_engine, ctx.guild.id, category.id)
         await ctx.reply("アーカイブカテゴリーを更新しました。")
 
     @commands.hybrid_command(name="setbanrole", description="BAN除外ロールを設定します")
     @commands.has_guild_permissions(administrator=True)
     async def set_ban_role(self, ctx: commands.Context, role: discord.Role) -> None:
-        await update_ban_role(self.bot.db_pool, ctx.guild.id, role.id)
+        await update_ban_role(self.bot.db_engine, ctx.guild.id, role.id)
         await ctx.reply("BAN除外ロールを更新しました。")
 
     @commands.hybrid_command(name="showconfig", description="現在の設定を表示します")
     async def show_config(self, ctx: commands.Context) -> None:
-        conf = await fetch_config(self.bot.db_pool, ctx.guild.id)
+        conf = await fetch_config(self.bot.db_engine, ctx.guild.id)
         if conf:
             embed = discord.Embed(title="ギルド設定")
             embed.add_field(name="Archive Category", value=f"<#{conf.archive_category_id}>")

--- a/db.py
+++ b/db.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from sqlalchemy import (
+    MetaData,
+    Table,
+    Column,
+    BigInteger,
+    Integer,
+    Text,
+    Boolean,
+    TIMESTAMP,
+    func,
+)
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+import config
+
+metadata = MetaData()
+
+guild_configs = Table(
+    "guild_configs",
+    metadata,
+    Column("guild_id", BigInteger, primary_key=True),
+    Column("archive_category_id", BigInteger, nullable=False),
+    Column("ban_allow_role_id", BigInteger, nullable=False),
+)
+
+discord_channels = Table(
+    "discord_channels",
+    metadata,
+    Column("channel_id", BigInteger, primary_key=True),
+    Column("guild_id", BigInteger, nullable=False),
+    Column("channel_name", Text, nullable=False),
+    Column("owner_name", Text, nullable=False),
+    Column("owner_user_id", BigInteger, nullable=False),
+)
+
+user_warnings = Table(
+    "user_warnings",
+    metadata,
+    Column("warning_id", Integer, primary_key=True),
+    Column("user_id", BigInteger, nullable=False),
+    Column("guild_id", BigInteger, nullable=False),
+    Column("message_content", Text, nullable=False),
+    Column("warning_timestamp", TIMESTAMP(timezone=True), nullable=False, server_default=func.now()),
+    Column("flag", Boolean, nullable=False, server_default="false"),
+)
+
+
+def create_engine() -> AsyncEngine:
+    """設定ファイルから AsyncEngine を生成"""
+    return create_async_engine(config.DATABASE_URL, echo=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ aiohttp
 asyncpg
 python-dotenv
 flask
+SQLAlchemy


### PR DESCRIPTION
## Summary
- add SQLAlchemy based models and engine
- switch guild_config helpers to SQLAlchemy queries
- refactor cogs to use the new engine
- update bot entrypoint to create async engine
- document SQLAlchemy usage and add requirement

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_684ae9d1a9cc8326b29e2e2164c377c0