### PR TITLE
Refactor config and add tests

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,9 @@
 from typing import List, Optional
 import os
 import discord
-from discord.ext import commands
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # ボットの設定
 # cogを追加するたびにここに追加していく
@@ -13,7 +15,8 @@ prefix = "!"
 DATABASE_URL = os.getenv('DATABASE_URL', 'sqlite:///:memory:')
 
 # テストギルドID (必要に応じて設定)
-testing_guild_id: Optional[int] = None
+_test_id_str = os.getenv("TESTING_GUILD_ID")
+testing_guild_id: Optional[int] = int(_test_id_str) if _test_id_str else None
 
 # その他環境変数
 ARCHIVE_CATEGORY_ID = int(os.getenv('ARCHIVE_CATEGORY_ID', 0))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,43 @@
+import importlib
+import os
+import sys
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+
+def reload_modules():
+    if 'config' in globals():
+        importlib.reload(config)
+    else:
+        import config
+    importlib.reload(config)
+    importlib.reload(db)
+
+
+@pytest.mark.parametrize('guild_id_env, expected', [
+    ('12345', 12345),
+    (None, None),
+])
+def test_testing_guild_id(monkeypatch, guild_id_env, expected):
+    monkeypatch.setenv('TESTING_GUILD_ID', guild_id_env) if guild_id_env else monkeypatch.delenv('TESTING_GUILD_ID', raising=False)
+    import importlib
+    import config
+    importlib.reload(config)
+    assert config.testing_guild_id == expected
+
+
+def test_create_engine_uses_env(monkeypatch):
+    url = 'postgresql://user:pass@localhost/db'
+    monkeypatch.setenv('DATABASE_URL', url)
+    import importlib
+    import config
+    importlib.reload(config)
+    import db
+    importlib.reload(db)
+    with mock.patch.object(db, 'create_async_engine') as fake_create:
+        db.create_engine()
+        fake_create.assert_called_once_with(url, echo=False)
+


### PR DESCRIPTION
## Summary
- load `.env` automatically in `config.py`
- parse `TESTING_GUILD_ID` from env
- add tests for configuration values

## Testing
- `pytest -q`
- `DATABASE_URL=sqlite:///:memory: pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684aee615c8c8326a5fc387050c224d8