### PR TITLE
環境変数を利用するテストの追加

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,15 +22,21 @@ def reload_modules():
     (None, None),
 ])
 def test_testing_guild_id(monkeypatch, guild_id_env, expected):
-    monkeypatch.setenv('TESTING_GUILD_ID', guild_id_env) if guild_id_env else monkeypatch.delenv('TESTING_GUILD_ID', raising=False)
+    print(f"TESTING_GUILD_ID={guild_id_env}")
+    if guild_id_env:
+        monkeypatch.setenv('TESTING_GUILD_ID', guild_id_env)
+    else:
+        monkeypatch.delenv('TESTING_GUILD_ID', raising=False)
     import importlib
     import config
     importlib.reload(config)
+    print(f"testing_guild_id -> {config.testing_guild_id}")
     assert config.testing_guild_id == expected
 
 
 def test_create_engine_uses_env(monkeypatch):
     url = 'postgresql://user:pass@localhost/db'
+    print(f"DATABASE_URL={url}")
     monkeypatch.setenv('DATABASE_URL', url)
     import importlib
     import config
@@ -40,4 +46,18 @@ def test_create_engine_uses_env(monkeypatch):
     with mock.patch.object(db, 'create_async_engine') as fake_create:
         db.create_engine()
         fake_create.assert_called_once_with(url, echo=False)
+    print("create_engine called with expected URL")
+
+
+def test_env_values_from_system():
+    import importlib
+    import config
+    env_archive = os.getenv('ARCHIVE_CATEGORY_ID')
+    env_ban_role = os.getenv('BAN_ALLOW_ROLE_ID')
+    print(f"ARCHIVE_CATEGORY_ID={env_archive}")
+    print(f"BAN_ALLOW_ROLE_ID={env_ban_role}")
+    importlib.reload(config)
+    assert config.ARCHIVE_CATEGORY_ID == int(env_archive)
+    assert config.BAN_ALLOW_ROLE_ID == int(env_ban_role)
+    print("環境変数から設定が読み込まれました")
 


### PR DESCRIPTION
## Summary
- `ARCHIVE_CATEGORY_ID` と `BAN_ALLOW_ROLE_ID` を実環境の値で読み込むテストを追加
- 既存テストにも `print` を入れて実行内容を表示

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684b0113937c83269eb124c2b5c8c9da